### PR TITLE
Add page for physio signals software

### DIFF
--- a/docs/analysis_software_physio.md
+++ b/docs/analysis_software_physio.md
@@ -1,0 +1,16 @@
+# Neuroimaging analysis software for physiological signals (ECG, EDA, EMG...)
+
+
+## NeuroKit2
+
+- [NeuroKit2](https://github.com/neuropsychology/NeuroKit): The Python Toolbox for Neurophysiological Signal Processing
+- repository URL:
+- website URL: [https://github.com/neuropsychology/NeuroKit](https://github.com/neuropsychology/NeuroKit)
+- tutorial URL: [tutorials](https://github.com/neuropsychology/NeuroKit#documentation)
+- documentation: [https://neurokit2.readthedocs.io/en/latest/](https://neurokit2.readthedocs.io/en/latest/)
+- programming language: [python]
+- paper DOI:
+- RRID:
+- contact: [issues](https://github.com/neuropsychology/NeuroKit/issues)
+
+


### PR DESCRIPTION
Biosignals (ECG, EDA, EMG, EGG, EOG etc.) are often used in conjunction with more traditional neuroimaging techniques, and are also, although indirectly, part of 'neuroimaging'. Thus I thought it'd be nice to have a page for that, and I added a software to kickstart it (conflicts of interest, I'm a contributor of that software ☺️). 

Maybe the title of the page could be shortened, but here it's consistent with the other 2 pages for MEEG and MRI.