### PR TITLE
broken link - contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://learn-neuroimaging.github.io/tutorials-and-resources
 We currently use mkdocs for our website. The "docs" directory contains ".md" pages containing domain-specific links to resources.
 
 ## How to add a resource and contribute
-See our contributing [guidelines](.CONTRIBUTING.md)
+See our contributing [guidelines](CONTRIBUTING.md)
 
 ## Get in touch
 


### PR DESCRIPTION
I'm not quite sure if there was supposed to be an extra period in the link itself
originally: 
https://github.com/learn-neuroimaging/tutorials-and-resources/blob/master/.CONTRIBUTING.md

But it did not work here on markdown as it was listed. Should this be changed?