### PR TITLE
Fixed Khan Academy typo

### DIFF
--- a/docs/data-repositories.md
+++ b/docs/data-repositories.md
@@ -132,6 +132,15 @@ an Resources Collaboratory](https://www.nitrc.org/).
 
 <!-- [Pain repository](https://www.painrepository.org/]) -->
 
+<!-- [Brain Development IXI Dataset]([https://brain-development.org/ixi-dataset/]) -->
+??? example "IXI Dataset - Brain Development from ICL"
+    -   [database repository](https://brain-development.org/ixi-dataset/)
+    -   contact: Biomedical Image Analysis Group, Imperial College London
+    -   data type: {human} {MRI} {DTI}
+    -   RRID: [SCR_005839](https://scicrunch.org/resources/Any/record/nlx_144509-1/SCR_005839/resolver?q=*&l=)
+    -   Nearly 600 MR images from normal, healthy subjects. The MR image acquisition protocol for each subject includes: T1, T2 and PD-weighted images, MRA images, and Diffusion-weighted images (15 directions).
+
+
 #### fNIRS
 
 ## Electrophysiology

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -65,3 +65,6 @@ Git and GitHub](https://journals.plos.org/ploscompbiol/article?id=10.1371/journa
 
 ## Introduction & Basics
 -   [Khan Academy](https://www.khanacademy.org/): Beginners' coursework on programming, algorithms, and more.
+
+## General
+- [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/): 11 videos ranging from 45min-1h25 about debugging, data wrangling, and useful tools. By @anishathalye, @jjgo and @jonhoo from MIT.

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -64,4 +64,4 @@ Git and GitHub](https://journals.plos.org/ploscompbiol/article?id=10.1371/journa
 -   [Introduction to Neurohacking in R](https://www.coursera.org/learn/neurohacking) MOOC on coursera
 
 ## Introduction & Basics
--   [Khan Academy] (https://www.khanacademy.org/): Beginners' coursework on programming, algorithms, and more.
+-   [Khan Academy](https://www.khanacademy.org/): Beginners' coursework on programming, algorithms, and more.


### PR DESCRIPTION
Hi there, I've just fixed a typo in the Khan Academy resource since I noticed it wasn't hyperlinking properly on your website. I've also added the IXI dataset resource and the "missing semester of your CS education" educational resource